### PR TITLE
Fix a small bug where delete objectstore config is not run

### DIFF
--- a/transfer.php
+++ b/transfer.php
@@ -167,6 +167,7 @@ if (!$process->isSuccessful()) {
     throw new ProcessFailedException($process);
 }
 $process = new Process(['php', $PATH_NEXTCLOUD . DIRECTORY_SEPARATOR . 'occ', 'config:system:delete', 'objectstore']);
+$process->run();
 if (!$process->isSuccessful()) {
     throw new ProcessFailedException($process);
 }


### PR DESCRIPTION
$process->isSuccessful() is called before run(), which leads to exception "Process must be started before calling getOutput()"